### PR TITLE
Some small fixes/improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+0.9 - 15/01/2014
+----------------
+Don't replace photos with identical file names at upload
+Fix root gallery discovery when root gallery is not named "Galleries"
+Reduce number of calls to PhotoDeck API
+Minor fixes
+
 0.8 - 29/12/2014
---------------------
+----------------
 Fix republishing deleted photos
 Add getPhoto API to give some details of photos, including contents
 Correct published URLs for photos

--- a/Info.lua
+++ b/Info.lua
@@ -9,5 +9,5 @@ return {
         title = "PhotoDeck", -- this string appears in the Publish Services panel
         file = "PhotoDeckPublishServiceProvider.lua", -- the service definition script
     },
-    VERSION = { major=0, minor=8, revision=1 },
+    VERSION = { major=0, minor=9, revision=1 },
 }

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -98,12 +98,17 @@ local function handle_errors(response, resp_headers, onerror)
   local status = PhotoDeckUtils.filter(resp_headers, function(v) return isTable(v) and v.field == 'Status' end)[1]
 
   if not status or status.value > "400" then
-    local statuscode = string.sub(status.value, 1, 3)
+    local statuscode
+    if status then
+      statuscode = string.sub(status.value, 1, 3)
+    end
     if onerror and onerror[statuscode] then
       return onerror[statuscode]()
     end
-    logger:error("Bad response: " .. response)
-    logger:error(PhotoDeckUtils.printLrTable(resp_headers))
+    logger:error("Bad response: " .. (response or "(no response)"))
+    if resp_headers then
+      logger:error(PhotoDeckUtils.printLrTable(resp_headers))
+    end
     -- raise this up to the user at this point?
   end
   return response

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -15,6 +15,7 @@ local isTable = PhotoDeckUtils.isTable
 local printTable = PhotoDeckUtils.printTable
 
 local PhotoDeckAPI = {}
+local PhotoDeckAPICache = {}
 
 -- sign API request according to docs at
 -- http://www.photodeck.com/developers/get-started/
@@ -179,9 +180,13 @@ end
 
 function PhotoDeckAPI.websites()
   logger:trace('PhotoDeckAPI.websites')
-  local response, headers = PhotoDeckAPI.request('GET', '/websites.xml', { view = 'details' })
-  local result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.websites)
-  -- logger:trace(printTable(result))
+  local result = PhotoDeckAPICache['websites']
+  if not result then
+    local response, headers = PhotoDeckAPI.request('GET', '/websites.xml', { view = 'details' })
+    result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.websites)
+    PhotoDeckAPICache['websites'] = result
+    -- logger:trace(printTable(result))
+  end
   return result
 end
 

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -311,7 +311,6 @@ function PhotoDeckAPI.uploadPhoto( exportSettings, t)
   local website = PhotoDeckAPI.websites()[exportSettings.websiteChosen]
   local headers = auth_headers('POST', '/medias.xml')
   local content = {
-    { name = 'media[replace]', value = "1" },
     { name = 'media[content]', filePath = t.filePath,
       fileName = PhotoDeckUtils.basename(t.filePath), contentType = 'image/jpeg' },
     { name = 'media[publish_to_galleries]', value = t.gallery.uuid }

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -247,7 +247,14 @@ function PhotoDeckAPI.createOrUpdateGallery(publishSettings, name, collectionInf
   local urlname = publishSettings.websiteChosen
   local website = PhotoDeckAPI.websites()[urlname]
   local galleries = PhotoDeckAPI.galleries(urlname)
-  local parentgallery = galleries["Galleries"]
+  local rootgallery = nil
+  for _, gallery in pairs(galleries) do
+    if not gallery['parentuuid'] or gallery['parentuuid'] == "" then
+      rootgallery = gallery
+      break
+    end
+  end
+  local parentgallery = rootgallery
   local collection = collectionInfo.publishedCollection
   -- prefer remote Id, particularly for renames, but optionally defer to name
   local gallery = galleries[collection:getRemoteId()] or galleries[name]
@@ -258,7 +265,7 @@ function PhotoDeckAPI.createOrUpdateGallery(publishSettings, name, collectionInf
     parentgallery = galleries[parent.remoteCollectionId] or galleries[parent.name]
     if not parentgallery then
       parentgallery = PhotoDeckAPI.createGallery(urlname, parent.name, parent,
-          galleries["Galleries"].uuid)
+          rootgallery.uuid)
     end
     local parentCollection = collection.catalog:getPublishedCollectionByLocalIdentifier(parent.localCollectionId)
     parentgallery.fullurl = website.homeurl .. "/-/" .. parentgallery.fullurlpath

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -198,6 +198,14 @@ function PhotoDeckAPI.galleries(urlname)
   return result
 end
 
+function PhotoDeckAPI.gallery(urlname, galleryId)
+  logger:trace('PhotoDeckAPI.gallery')
+  local response, headers = PhotoDeckAPI.request('GET', '/websites/' .. urlname .. '/galleries/' .. galleryId .. '.xml', { view = 'details' })
+  local result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.gallery)
+  -- logger:trace(printTable(result))
+  return result
+end
+
 local function buildGalleryInfo(gallery)
   local galleryInfo = {}
   if gallery.getCollectionInfoSummary then
@@ -214,9 +222,10 @@ function PhotoDeckAPI.createGallery(urlname, name, gallery, parentId)
   galleryInfo['gallery[parent]'] = parentId
   galleryInfo['gallery[name]'] = name
   logger:trace(printTable(galleryInfo))
-  PhotoDeckAPI.request('POST', '/websites/' .. urlname .. '/galleries.xml', galleryInfo)
-  local galleries = PhotoDeckAPI.galleries(urlname)
-  return galleries[name]
+  local response, headers = PhotoDeckAPI.request('POST', '/websites/' .. urlname .. '/galleries.xml', galleryInfo)
+  local result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.createGallery)
+  local gallery = PhotoDeckAPI.gallery(urlname, result['uuid'])
+  return gallery
 end
 
 function PhotoDeckAPI.updateGallery(urlname, uuid, newname, gallery, parentId)
@@ -228,8 +237,8 @@ function PhotoDeckAPI.updateGallery(urlname, uuid, newname, gallery, parentId)
   logger:trace(printTable(galleryInfo))
   local response = PhotoDeckAPI.request('PUT', '/websites/' .. urlname .. '/galleries/' .. uuid .. '.xml', galleryInfo)
   logger:trace('PhotoDeckAPI.updateGallery: ' .. response)
-  local galleries = PhotoDeckAPI.galleries(urlname)
-  return galleries[newname]
+  local gallery = PhotoDeckAPI.gallery(urlname, uuid)
+  return gallery
 end
 
 

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -397,10 +397,14 @@ end
 
 function PhotoDeckAPI.galleryDisplayStyles(urlname)
   logger:trace('PhotoDeckAPI.galleryDisplayStyles')
-  local url = '/websites/' .. urlname .. '/gallery_display_styles.xml'
-  local response, headers = PhotoDeckAPI.request('GET', url, { view = 'details' })
-  local result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.galleryDisplayStyles)
-  logger:trace('PhotoDeckAPI.galleryDisplayStyles: ' .. printTable(result))
+  local result = PhotoDeckAPICache['gallery_display_styles/' .. urlname]
+  if not result then
+    local url = '/websites/' .. urlname .. '/gallery_display_styles.xml'
+    local response, headers = PhotoDeckAPI.request('GET', url, { view = 'details' })
+    result = PhotoDeckAPIXSLT.transform(response, PhotoDeckAPIXSLT.galleryDisplayStyles)
+    PhotoDeckAPICache['gallery_display_styles/' .. urlname] = result
+    logger:trace('PhotoDeckAPI.galleryDisplayStyles: ' .. printTable(result))
+  end
   return result
 end
 

--- a/PhotoDeckAPI.lua
+++ b/PhotoDeckAPI.lua
@@ -258,15 +258,14 @@ function PhotoDeckAPI.createOrUpdateGallery(publishSettings, name, collectionInf
   local collection = collectionInfo.publishedCollection
   -- prefer remote Id, particularly for renames, but optionally defer to name
   local gallery = galleries[collection:getRemoteId()] or galleries[name]
-  -- no idea how to deal with multiple parents as yet
-  assert(not collectionInfo.parents or #collectionInfo.parents < 2)
   for _, parent in pairs(collectionInfo.parents) do
     logger:trace(printTable(parent))
-    parentgallery = galleries[parent.remoteCollectionId] or galleries[parent.name]
-    if not parentgallery then
-      parentgallery = PhotoDeckAPI.createGallery(urlname, parent.name, parent,
-          rootgallery.uuid)
+    local galleryforparent = galleries[parent.remoteCollectionId] or galleries[parent.name]
+    if not galleryforparent then
+      galleryforparent = PhotoDeckAPI.createGallery(urlname, parent.name, parent,
+          parentgallery.uuid)
     end
+    parentgallery = galleryforparent
     local parentCollection = collection.catalog:getPublishedCollectionByLocalIdentifier(parent.localCollectionId)
     parentgallery.fullurl = website.homeurl .. "/-/" .. parentgallery.fullurlpath
     if parentCollection and (not parent.remoteCollectionId or parentCollection:getRemoteId() ~= parent.remoteCollectionId or parentCollection:getRemoteUrl() ~= parentgallery.fullurl) then

--- a/PhotoDeckAPIXSLT.lua
+++ b/PhotoDeckAPIXSLT.lua
@@ -63,6 +63,27 @@ return t
   </xsl:template>
 ]] .. xsltfooter
 
+PhotoDeckAPIXSLT.gallery = xsltheader .. [[
+  <xsl:template match='/reply/gallery'>
+local t = {
+     fullurlpath = "<xsl:value-of select='full-url-path'/>",
+     name = "<xsl:value-of select='name'/>",
+     uuid = "<xsl:value-of select='uuid'/>",
+     urlpath = "<xsl:value-of select='url-path'/>",
+}
+return t
+  </xsl:template>
+]] .. xsltfooter
+
+PhotoDeckAPIXSLT.createGallery = xsltheader .. [[
+  <xsl:template match='/reply'>
+local t = {
+     uuid = "<xsl:value-of select='gallery-uuid'/>",
+}
+return t
+  </xsl:template>
+]] .. xsltfooter
+
 PhotoDeckAPIXSLT.getPhoto = xsltheader .. [[
   <xsl:template match='/reply/media'>
 local t = {

--- a/PhotoDeckAPIXSLT.lua
+++ b/PhotoDeckAPIXSLT.lua
@@ -28,16 +28,15 @@ return t
 
 PhotoDeckAPIXSLT.websites = xsltheader .. [[
   <xsl:template match='/reply/websites'>
+local t = {}
     <xsl:for-each select='website'>
-local t = { <xsl:value-of select='urlname'/> =
-  {
+t["<xsl:value-of select='urlname'/>"] = {
      hostname = "<xsl:value-of select='hostname'/>",
      homeurl = "<xsl:value-of select='home-url'/>",
      title = "<xsl:value-of select='title'/>",
-  },
 }
-return t
     </xsl:for-each>
+return t
   </xsl:template>
 ]] .. xsltfooter
 

--- a/PhotoDeckPublishServiceProvider.lua
+++ b/PhotoDeckPublishServiceProvider.lua
@@ -343,6 +343,9 @@ function publishServiceProvider.processRenderedPhotos( functionContext, exportCo
 
   if not galleryId then
     -- Create or update this gallery.
+    if not collectionInfo.publishedCollection then
+      collectionInfo.publishedCollection = exportContext.publishedCollection
+    end
     gallery = PhotoDeckAPI.createOrUpdateGallery(exportSettings, collectionInfo.name, collectionInfo)
   else
     gallery = galleries[galleryId]

--- a/PhotoDeckPublishServiceProvider.lua
+++ b/PhotoDeckPublishServiceProvider.lua
@@ -349,7 +349,7 @@ function publishServiceProvider.processRenderedPhotos( functionContext, exportCo
     if not collectionInfo.publishedCollection then
       collectionInfo.publishedCollection = exportContext.publishedCollection
     end
-    gallery = PhotoDeckAPI.createOrUpdateGallery(exportSettings, collectionInfo.name, collectionInfo)
+    gallery = PhotoDeckAPI.createOrUpdateGallery(urlname, collectionInfo.name, collectionInfo)
   end
 
   -- gather information for dealing with recordPublishedPhotoUrl bug
@@ -370,7 +370,7 @@ function publishServiceProvider.processRenderedPhotos( functionContext, exportCo
     local photo = rendition.photo
 
     -- See if we previously uploaded this photo.
-    local photodeckPhotoId = rendition.publishedPhotoId or uploadedPhotoIds[photo.localIdentifier]
+    local photoId = rendition.publishedPhotoId or uploadedPhotoIds[photo.localIdentifier]
 
     if not rendition.wasSkipped then
       local success, pathOrMessage = rendition:waitForRender()
@@ -382,16 +382,15 @@ function publishServiceProvider.processRenderedPhotos( functionContext, exportCo
         -- Upload or replace the photo.
         local upload
 
-        if photodeckPhotoId and PhotoDeckAPI.getPhoto(photodeckPhotoId) then
-          upload = PhotoDeckAPI.updatePhoto( exportSettings, {
+        if photoId and PhotoDeckAPI.getPhoto(photoId) then
+          upload = PhotoDeckAPI.updatePhoto( photoId, urlname, {
             filePath = pathOrMessage,
-            gallery = gallery,
-            uuid = photodeckPhotoId,
+            gallery = gallery
           })
         else
-          upload = PhotoDeckAPI.uploadPhoto( exportSettings, {
+          upload = PhotoDeckAPI.uploadPhoto( urlname, {
             filePath = pathOrMessage,
-            gallery = gallery,
+            gallery = gallery
           })
         end
 
@@ -423,6 +422,7 @@ publishServiceProvider.deletePhotosFromPublishedCollection = function( publishSe
   logger:trace('deletePhotosFromPublishedCollection')
   local catalog = LrApplication.activeCatalog()
   local collection = catalog:getPublishedCollectionByLocalIdentifier(localCollectionId)
+  local galleryId = collection:getRemoteId()
   -- this next bit is stupid. Why is there no catalog:getPhotoByRemoteId or similar
   local publishedPhotos = collection:getPublishedPhotos()
   local publishedPhotoById = {}
@@ -431,7 +431,22 @@ publishServiceProvider.deletePhotosFromPublishedCollection = function( publishSe
   end
   for i, photoId in ipairs( arrayOfPhotoIds ) do
     local publishedPhoto = publishedPhotoById[photoId]
-    PhotoDeckAPI.removePhotoFromCollection(publishSettings, publishedPhoto, collection)
+
+    local collCount = 0
+    for _, c in pairs(publishedPhoto:getPhoto():getContainedPublishedCollections()) do
+      if c:getRemoteId() ~= galleryId then
+        collCount = collCount + 1
+      end
+    end
+
+    if collCount == 0 then
+      -- delete photo if this is the only collection it's in
+      PhotoDeckAPI.deletePhoto(photoId)
+    else
+      -- otherwise unpublish from the passed in collection
+      PhotoDeckAPI.unpublishPhoto(photoId, galleryId)
+    end
+
     deletedCallback( photoId )
   end
 end
@@ -491,23 +506,29 @@ publishServiceProvider.viewForCollectionSettings = function( f, publishSettings,
 end
 
 publishServiceProvider.updateCollectionSettings = function( publishSettings, info )
-  PhotoDeckAPI.createOrUpdateGallery(publishSettings, info.collectionSettings.LR_liveName, info)
+  local urlname = publishSettings.websiteChosen
+  PhotoDeckAPI.createOrUpdateGallery(urlname, info.collectionSettings.LR_liveName, info)
 end
 
 publishServiceProvider.updateCollectionSetSettings = function( publishSettings, info )
-  PhotoDeckAPI.createOrUpdateGallery(publishSettings, info.name, info)
+  local urlname = publishSettings.websiteChosen
+  PhotoDeckAPI.createOrUpdateGallery(urlname, info.name, info)
 end
 
 publishServiceProvider.renamePublishedCollection = function( publishSettings, info )
-  PhotoDeckAPI.createOrUpdateGallery(publishSettings, info.name, info)
+  local urlname = publishSettings.websiteChosen
+  PhotoDeckAPI.createOrUpdateGallery(urlname, info.name, info)
 end
 
 publishServiceProvider.reparentPublishedCollection = function( publishSettings, info )
-  PhotoDeckAPI.createOrUpdateGallery(publishSettings, info.name, info)
+  local urlname = publishSettings.websiteChosen
+  PhotoDeckAPI.createOrUpdateGallery(urlname, info.name, info)
 end
 
 publishServiceProvider.deletePublishedCollection = function( publishSettings, info )
-  PhotoDeckAPI.deleteGallery(publishSettings, info)
+  local urlname = publishSettings.websiteChosen
+  local galleryId = info.remoteId
+  PhotoDeckAPI.deleteGallery(urlname, galleryId)
 end
 
 return publishServiceProvider

--- a/PhotoDeckPublishServiceProvider.lua
+++ b/PhotoDeckPublishServiceProvider.lua
@@ -337,18 +337,19 @@ function publishServiceProvider.processRenderedPhotos( functionContext, exportCo
   -- Look for a gallery id for this collection.
   local galleryId = collectionInfo.remoteId
   local galleryPhotos
-  local gallery
   local urlname = exportSettings.websiteChosen
-  local galleries = PhotoDeckAPI.galleries(urlname)
+  local gallery = nil
 
-  if not galleryId then
+  if galleryId then
+    gallery = PhotoDeckAPI.gallery(urlname, galleryId)
+  end
+
+  if not gallery then
     -- Create or update this gallery.
     if not collectionInfo.publishedCollection then
       collectionInfo.publishedCollection = exportContext.publishedCollection
     end
     gallery = PhotoDeckAPI.createOrUpdateGallery(exportSettings, collectionInfo.name, collectionInfo)
-  else
-    gallery = galleries[galleryId]
   end
 
   -- gather information for dealing with recordPublishedPhotoUrl bug


### PR DESCRIPTION
1. couple of minor fixes
2. cache some API replies for the duration of the LR session (websites & gallery display styles)
3. don't replace photos with identical file names at upload (this is dangerous for users that don't care about file name uniqueness)
4. start reducing the use of the "full gallery listing" API endpoint, as it can be a bit slow/taxing on huge sites. More needs to be done here ;)
5. fix root gallery discovery when root gallery is not named "Galleries"
